### PR TITLE
use render function instead of jsx

### DIFF
--- a/src/components/BaseChart.tsx
+++ b/src/components/BaseChart.tsx
@@ -175,10 +175,19 @@ function generateChart(chartsId: string, chartsType: string) {
       }
     },
     render() {
-      return (
-        <div class={this.styles}>
-          <canvas ref="canvas" id={chartsId} width={(this as any).width} height={(this as any).height}></canvas>
-        </div>
+      return h(
+        'div',
+        { class: this.styles },
+        h(
+          'canvas',
+          { 
+            ref: 'canvas',
+            id: chartsId,
+            width: this.width,
+            height: this.height
+          },
+          null
+        )
       )
     }
   })


### PR DESCRIPTION
Hi, 

When using this package with Vite, by default it renders `BaseChart.tsx` component, and it uses JSX to render component.
I was not able to get it to compile with Vite, using regular render function as in `BaseChart.vue` seems to solve the issue.

Let me know if this breaks anything else.